### PR TITLE
* fixed incorrect dirname() result

### DIFF
--- a/jphp-zend-ext/src/main/java/org/develnext/jphp/zend/ext/standard/FileFunctions.java
+++ b/jphp-zend-ext/src/main/java/org/develnext/jphp/zend/ext/standard/FileFunctions.java
@@ -103,7 +103,7 @@ public class FileFunctions extends FunctionsContainer {
 
     @Immutable
     public static String dirname(String path){
-        return new File(path).getPath();
+        return new File(path).getParent();
     }
 
     public static Memory disk_free_space(String path){

--- a/jphp-zend-ext/src/main/tests/file/FileTest.java
+++ b/jphp-zend-ext/src/main/tests/file/FileTest.java
@@ -1,0 +1,18 @@
+package file;
+
+import org.develnext.jphp.zend.ZendJvmTestCase;
+import org.junit.FixMethodOrder;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.junit.runners.MethodSorters;
+
+@RunWith(JUnit4.class)
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
+public class FileTest extends ZendJvmTestCase {
+
+    @Test
+    public void testDirname() {
+        check("ext/file/dirname_001.php");
+    }
+}

--- a/jphp-zend-ext/src/main/tests/resources/ext/file/dirname_001.php
+++ b/jphp-zend-ext/src/main/tests/resources/ext/file/dirname_001.php
@@ -1,0 +1,21 @@
+--TEST--
+Test dirname() function : basic functionality
+--FILE--
+<?php
+
+$paths = array(
+			'/usr',
+			'/usr/',
+			'/usr/bin/',
+			'/usr/bin/env'
+			);
+
+foreach ($paths as $path) {
+	echo dirname($path) . "\n";
+}
+
+--EXPECTF--
+/
+/
+/usr
+/usr/bin


### PR DESCRIPTION
Before fix the problem function dirname() always returns path passed in argument, and condition `dirname(__FILE__) == __FILE__` was always true.
