### PR TITLE
Fix class Time

### DIFF
--- a/jphp-core/src/php/runtime/ext/core/classes/time/WrapTime.java
+++ b/jphp-core/src/php/runtime/ext/core/classes/time/WrapTime.java
@@ -69,6 +69,10 @@ public class WrapTime extends BaseObject implements IComparableObject<WrapTime> 
 
         this.date = new Date(args[0].toLong());
         this.timeZone = zone;
+        
+        calendar = Calendar.getInstance(timeZone);
+        calendar.setTime(date);
+        
         return Memory.NULL;
     }
 


### PR DESCRIPTION
Code:

``` php
$time = new Time(0);
$time->millisecond();
```

Error:

```
Fatal error: Uncaught exception 'php\lang\JavaException' with message 'java.lang.NullPointerException' in bootstrap_test.php on line 12, position 10
Stack Trace:
#0 php\time\Time->millisecond() called at [bootstrap_test.php:12]
#1 {main}
  thrown in bootstrap_test.php on line 12

JVM Stack trace:
  php.runtime.ext.core.classes.time.WrapTime.millisecond(WrapTime.java:154)
  java.lang.reflect.Method.invoke(Method.java:483)
  php.runtime.reflection.MethodEntity.invokeDynamic(MethodEntity.java:236)
  php.runtime.invoke.ObjectInvokeHelper.invokeMethod(ObjectInvokeHelper.java:178)
  include (bootstrap_test.php:10)
  java.lang.reflect.Method.invoke(Method.java:483)
  php.runtime.reflection.ModuleEntity.include(ModuleEntity.java:77)
  php.runtime.launcher.Launcher.run(Launcher.java:203)
  php.runtime.launcher.Launcher.run(Launcher.java:179)
  php.runtime.launcher.Launcher.run(Launcher.java:175)
  php.runtime.launcher.Launcher.main(Launcher.java:236)
```
