### PR TITLE
* Fixed RuntimeException

### DIFF
--- a/jphp-core/src/org/develnext/jphp/core/tokenizer/Tokenizer.java
+++ b/jphp-core/src/org/develnext/jphp/core/tokenizer/Tokenizer.java
@@ -636,13 +636,14 @@ public class Tokenizer {
                     startRelativePosition = relativePosition;
                     EchoRawToken token = buildToken(EchoRawToken.class, meta);
 
-                    if (code.substring(currentPosition + 1, currentPosition + 4).equals("php")){
+                    if (codeLength >= currentPosition + 4 &&
+                            code.substring(currentPosition + 1, currentPosition + 4).equals("php")){
                         relativePosition += 4;
                         currentPosition += 3;
                         token.setShort(false);
-                    } else
+                    } else {
                         token.setShort(true);
-
+                    }
                     return token;
                 } else {
                     init = true;


### PR DESCRIPTION
Code:

``` php
<?
```

Actual result:

```
Exception in thread "main" java.lang.RuntimeException: java.lang.StringIndexOutOfBoundsException: String index out of range: 5
    at php.runtime.env.Environment.catchUncaught(Environment.java:721)
    at org.develnext.jphp.cli.CLI.checkSyntax(CLI.java:59)
    at org.develnext.jphp.cli.CLI.process(CLI.java:102)
    at org.develnext.jphp.cli.CLI.main(CLI.java:114)
Caused by: java.lang.StringIndexOutOfBoundsException: String index out of range: 5
    at java.lang.String.substring(String.java:1907)
    at org.develnext.jphp.core.tokenizer.Tokenizer.nextToken(Tokenizer.java:639)
    at org.develnext.jphp.core.syntax.SyntaxAnalyzer.process(SyntaxAnalyzer.java:176)
    at org.develnext.jphp.core.syntax.SyntaxAnalyzer.<init>(SyntaxAnalyzer.java:124)
    at org.develnext.jphp.core.syntax.SyntaxAnalyzer.<init>(SyntaxAnalyzer.java:51)
    at org.develnext.jphp.cli.CLI.checkSyntax(CLI.java:55)
    ... 2 more
```
