### PR TITLE
Support comma-separeted expressions in condition of FOR statement

### DIFF
--- a/jphp-core/src/org/develnext/jphp/core/compiler/jvm/statement/expr/ForCompiler.java
+++ b/jphp-core/src/org/develnext/jphp/core/compiler/jvm/statement/expr/ForCompiler.java
@@ -1,5 +1,7 @@
 package org.develnext.jphp.core.compiler.jvm.statement.expr;
 
+import java.util.Iterator;
+
 import org.develnext.jphp.core.compiler.jvm.misc.LocalVariable;
 import org.develnext.jphp.core.compiler.jvm.statement.ExpressionStmtCompiler;
 import org.develnext.jphp.core.tokenizer.token.expr.value.VariableExprToken;
@@ -37,11 +39,18 @@ public class ForCompiler extends BaseStatementCompiler<ForStmtToken> {
         LabelNode iter = new LabelNode();
         LabelNode end = new LabelNode();
 
-        expr.writeExpression(token.getCondition(), true, false);
-        expr.writePopBoolean();
+	for (Iterator<ExprStmtToken> i = token.getConditionExpr().iterator(); i.hasNext();) {
+	    ExprStmtToken expr = i.next();
+	    if (i.hasNext()) {
+		this.expr.writeExpression(expr, false, false);
+	    } else {
+		this.expr.writeExpression(expr, true, false);
+		this.expr.writePopBoolean();
 
-        add(new JumpInsnNode(IFEQ, end));
-        expr.stackPop();
+		add(new JumpInsnNode(IFEQ, end));
+		this.expr.stackPop();
+	    }
+        }
 
         method.pushJump(end, iter);
         expr.write(BodyStmtToken.class, token.getBody());

--- a/jphp-core/src/org/develnext/jphp/core/syntax/generators/ExprGenerator.java
+++ b/jphp-core/src/org/develnext/jphp/core/syntax/generators/ExprGenerator.java
@@ -291,8 +291,23 @@ public class ExprGenerator extends Generator<ExprStmtToken> {
         result.setInitLocal(analyzer.removeScope().getVariables());
         analyzer.addScope().setLevelForGoto(true);
 
-        ExprStmtToken condition = analyzer.generator(SimpleExprGenerator.class)
-                .getToken(nextToken(iterator), iterator, Separator.SEMICOLON, null);
+        // CONDITIONS
+        List<ExprStmtToken> conditions = new ArrayList<ExprStmtToken>();
+
+        do {
+            ExprStmtToken conditionExpr = analyzer.generator(SimpleExprGenerator.class)
+                .getToken(nextToken(iterator), iterator, Separator.COMMA_OR_SEMICOLON, null);
+            if (conditionExpr == null)
+                break;
+
+            conditions.add(conditionExpr);
+
+            if (iterator.previous() instanceof SemicolonToken) {
+                iterator.next();
+                break;
+            }
+            iterator.next();
+        } while (true);
 
         // ITERATIONS
         List<ExprStmtToken> iterations = new ArrayList<ExprStmtToken>();
@@ -322,7 +337,7 @@ public class ExprGenerator extends Generator<ExprStmtToken> {
             iterator.next();
 
         result.setInitExpr(inits);
-        result.setCondition(condition);
+        result.setConditionExpr(conditions);
         result.setIterationExpr(iterations);
         result.setBody(body);
         result.setLocal(analyzer.removeScope().getVariables());

--- a/jphp-core/src/org/develnext/jphp/core/tokenizer/token/stmt/ForStmtToken.java
+++ b/jphp-core/src/org/develnext/jphp/core/tokenizer/token/stmt/ForStmtToken.java
@@ -12,7 +12,7 @@ public class ForStmtToken extends StmtToken {
     private Set<VariableExprToken> initLocal;
     private Set<VariableExprToken> iterationLocal;
     private List<ExprStmtToken> initExpr;
-    private ExprStmtToken condition;
+    private List<ExprStmtToken> conditionExpr;
     private List<ExprStmtToken> iterationExpr;
 
     private BodyStmtToken body;
@@ -29,12 +29,12 @@ public class ForStmtToken extends StmtToken {
         this.initExpr = initExpr;
     }
 
-    public ExprStmtToken getCondition() {
-        return condition;
+    public List<ExprStmtToken> getConditionExpr() {
+        return conditionExpr;
     }
 
-    public void setCondition(ExprStmtToken condition) {
-        this.condition = condition;
+    public void setConditionExpr(List<ExprStmtToken> conditionExpr) {
+        this.conditionExpr = conditionExpr;
     }
 
     public List<ExprStmtToken> getIterationExpr() {

--- a/jphp-zend-ext/src/main/tests/resources/zend/lang/041.php
+++ b/jphp-zend-ext/src/main/tests/resources/zend/lang/041.php
@@ -1,0 +1,18 @@
+--TEST--
+Testing for loop with multiple expressions in init/cond/incr parts.
+--FILE--
+<?php
+for ($i=1,$j=10; print("$i\n"),$i<5; $i++,$j++) {
+    print("$j\n");
+}
+?>
+--EXPECT--
+1
+10
+2
+11
+3
+12
+4
+13
+5

--- a/jphp-zend-ext/src/main/tests/resources/zend/lang/042.php
+++ b/jphp-zend-ext/src/main/tests/resources/zend/lang/042.php
@@ -1,0 +1,16 @@
+--TEST--
+Testing for loop without condition
+--FILE--
+<?php
+$i=0;
+for (;;) {
+    print("$i\n");
+    if ($i>=3) break;
+    $i++;
+}
+?>
+--EXPECT--
+0
+1
+2
+3

--- a/jphp-zend-ext/src/main/tests/zend/LangTest.java
+++ b/jphp-zend-ext/src/main/tests/zend/LangTest.java
@@ -52,6 +52,7 @@ public class LangTest extends ZendJvmTestCase {
 
         check("zend/lang/040.php");
         check("zend/lang/041.php");
+        check("zend/lang/042.php");
 
 
         check("zend/lang/array_shortcut_001.php");

--- a/jphp-zend-ext/src/main/tests/zend/LangTest.java
+++ b/jphp-zend-ext/src/main/tests/zend/LangTest.java
@@ -51,6 +51,7 @@ public class LangTest extends ZendJvmTestCase {
         check("zend/lang/037.php");
 
         check("zend/lang/040.php");
+        check("zend/lang/041.php");
 
 
         check("zend/lang/array_shortcut_001.php");


### PR DESCRIPTION
PHP's `for` statement can be expressed like this:
```
for (expr1;expr2;expr3)
    statement
```

All `expr` accept comma-separated expressions in original PHP, however JPHP accepts just 1 expression in `expr2`. So this PR supports multiple expressions in `expr2`.