### PR TITLE
Fix casting numeric string as array key

### DIFF
--- a/jphp-runtime/src/php/runtime/memory/ArrayMemory.java
+++ b/jphp-runtime/src/php/runtime/memory/ArrayMemory.java
@@ -1029,7 +1029,8 @@ public class ArrayMemory extends Memory implements Iterable<ReferenceMemory> {
 
     @Override
     public Memory valueOfIndex(TraceInfo trace, String index) {
-        Memory e = getByScalar(index);
+        Memory number = StringMemory.toLong(index);
+        Memory e = number == null ? getByScalar(index) : getByScalar(number);
         return e == null ? UNDEFINED : e;
     }
 

--- a/jphp-zend-ext/src/main/tests/resources/zend/lang/043.php
+++ b/jphp-zend-ext/src/main/tests/resources/zend/lang/043.php
@@ -1,0 +1,12 @@
+--TEST--
+Testing array access with numeric key
+--FILE--
+<?php
+$a = [2 => '3'];
+$a['2'] = '4';
+var_dump($a[2]);
+var_dump($a['2']);
+?>
+--EXPECT--
+string(1) "4"
+string(1) "4"

--- a/jphp-zend-ext/src/main/tests/zend/LangTest.java
+++ b/jphp-zend-ext/src/main/tests/zend/LangTest.java
@@ -53,6 +53,7 @@ public class LangTest extends ZendJvmTestCase {
         check("zend/lang/040.php");
         check("zend/lang/041.php");
         check("zend/lang/042.php");
+        check("zend/lang/043.php");
 
 
         check("zend/lang/array_shortcut_001.php");


### PR DESCRIPTION
Fix casting numeric string as array key to integer when reading array value. 