### PR TITLE
Enable depedency caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 dist: trusty # xenial fail to install oraclejdk8
 language: java
 
+cache:
+  directories:
+    - $HOME/.gradle
+
 jdk:
   - openjdk11
   - openjdk8


### PR DESCRIPTION
Would be interested to know why gradle dependencies haven't been cached on Travis. Thank you.